### PR TITLE
Implemented headless construction for homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,10 @@
 {{ define "main" }}
+{{ $headless := .Site.GetPage "/homepage" }}
+{{ $sections := $headless.Resources.ByType "page" }}
+{{ $sections := cond .Site.BuildDrafts $sections (where $sections "Draft" "==" false) }}
 
   <main>
-      {{ range $index, $val := ( where .Site.RegularPages "Type" "posts" ) }}
+      {{ range $index, $val := $sections }}
       <div class="block">
 
       <div class="title" onclick="expandDiv({{$index}})">{{ .Title }}</div>


### PR DESCRIPTION
Updated the file structure behind to range loop to regard files as headless blocks instead of individual posts/pages. This prevents the individual blocks on the homepage to also be published as stand-alone webpages.